### PR TITLE
fix: account for single-quote directives

### DIFF
--- a/.changeset/strange-tools-smile.md
+++ b/.changeset/strange-tools-smile.md
@@ -1,0 +1,5 @@
+---
+"esbuild-plugin-preserve-directives": patch
+---
+
+Account for single-quote directives

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esbuild-plugin-preserve-directives",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "An esbuild plugin to preserve important directives like 'use client' at the top of output files.",
   "author": "seojunhwan <seojunhwan@kakao.com>",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,13 @@ export function preserveDirectivesPlugin(options: DirectivePreservationOptions):
 
         const foundDirectives = lines
           .slice(0, 5)
-          .filter((line) => directives.some((directive) => line.trim().startsWith(`"${directive}"`)));
+          .filter((line) =>
+            directives.some(
+              (directive) =>
+                line.trim().startsWith(`"${directive}"`) ||
+                line.trim().startsWith(`'${directive}'`)
+            )
+          );
 
         if (foundDirectives.length > 0) {
           const relativePath = getRelativePath(args.path);


### PR DESCRIPTION
Before this PR, this resolved directives wrapped in double-quotes (`"use client"`), but not directives in single-quotes (`'use client'`). 

This PR resolves it.

_Thanks for the plugin btw._