### PR TITLE
fix: account for backtick directive

### DIFF
--- a/.changeset/silver-badgers-draw.md
+++ b/.changeset/silver-badgers-draw.md
@@ -1,0 +1,5 @@
+---
+"esbuild-plugin-preserve-directives": patch
+---
+
+account for backtick directive

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,8 @@ export function preserveDirectivesPlugin(options: DirectivePreservationOptions):
             directives.some(
               (directive) =>
                 line.trim().startsWith(`"${directive}"`) ||
-                line.trim().startsWith(`'${directive}'`)
+                line.trim().startsWith(`'${directive}'`) ||
+                line.trim().startsWith(`\`${directive}\``)
             )
           );
 


### PR DESCRIPTION
I was inspired by #15. Thanks @adamsoderstrom I really appreciated it!

I believe that we should also handle directives wrapped in backticks.
