### PR TITLE
build(npm): remove `"type": "module"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "seojunhwan <seojunhwan@kakao.com>",
   "license": "MIT",
   "main": "./dist/index.js",
-  "type": "module",
   "exports": {
     ".": {
       "require": {


### PR DESCRIPTION
Due to `tsup` not supporting `tsup.config.mts`

# Steps to reproduce

1. Clone example showcasing the bug - https://github.com/adamsoderstrom/eslint-module-resolution-bug-example
2. Open `eslint-module-resolution-bug-example/packages/ui/tsup.config.ts`
3. See the following error:

```
typescript: The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("esbuild-plugin-preserve-directives")' call instead.
  To convert this file to an ECMAScript module, change its file extension to '.mts', or add the field `"type": "module"` to '~/eslint-module-resolution-bug-example/packages/ui/package.json'. [1479]
```