### PR TITLE
Bump esbuild version in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "esbuild": "^0.21.0"
+    "esbuild": "^0.23.0"
   }
 }


### PR DESCRIPTION
Bump esbuild version in peer dependencies, to remove type error when using tsup v8.3.0 (uses esbuild 0.23.0).